### PR TITLE
Remove obsolete factura style block

### DIFF
--- a/style.css
+++ b/style.css
@@ -321,8 +321,6 @@ h2, h3 {
 .loading-overlay { display: none; position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(255, 255, 255, 0.7); z-index: 9999; justify-content: center; align-items: center; }
 .spinner { width: 50px; height: 50px; border: 5px solid rgba(0, 0, 0, 0.1); border-left-color: var(--color-primario); border-radius: 50%; animation: spin 1s linear infinite; }
 @keyframes spin { to { transform: rotate(360deg); } }
-/* Factura (obsoleto, reemplazado por los estilos de abajo) */
-#plantilla-factura { width: 210mm; height: 296mm; padding: 15mm; box-sizing: border-box; background-color: white; color: #333; font-family: 'Helvetica', 'Arial', sans-serif; font-size: 10px; display: flex; flex-direction: column; }
 /* Responsive */
 @media (max-width: 768px) {
     .sidebar { position: fixed; left: -250px; top: 0; height: 100%; transition: left 0.3s ease-in-out; z-index: 1000; box-shadow: 5px 0px 15px rgba(0,0,0,0.2); }


### PR DESCRIPTION
## Summary
- remove deprecated `#plantilla-factura` CSS block
- keep current PDF invoice styles intact

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8df85e80c8332888a1bb0e62ea7f7