### PR TITLE
Sanitize image URLs in product views

### DIFF
--- a/manual-tests.md
+++ b/manual-tests.md
@@ -1,0 +1,7 @@
+# Manual Tests
+
+## Image Rendering
+1. Open `index.html` in a browser.
+2. Create or edit a product with a **local** image path, e.g. `bandeja.png`. The image should render in card and list views.
+3. Create or edit a product with a **remote** image URL, e.g. `https://via.placeholder.com/150`. The remote image should also render.
+4. Try using a URL that begins with `javascript:` or `data:`. The image should be rejected and not displayed.


### PR DESCRIPTION
## Summary
- Merge URL building and sanitization into a single `buildImageSrc` helper to reject `javascript:` and `data:` schemes
- Use `buildImageSrc` when rendering product images in card and table views
- Add manual tests covering local and remote image URLs

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8df73aa5c8332819a8c6894fe66f2