### PR TITLE
Add scroll-to-top button for easier navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -709,7 +709,16 @@ document.addEventListener('DOMContentLoaded', () => {
         localStorage.setItem('amazonia_dark', isDark);
         toastInfo(isDark ? 'Tema oscuro activado' : 'Tema claro activado');
     });
-    
+
+    const scrollBtn = document.getElementById('btn-scroll-top');
+    window.addEventListener('scroll', () => {
+        if (window.scrollY > 300) scrollBtn.classList.add('mostrar');
+        else scrollBtn.classList.remove('mostrar');
+    });
+    scrollBtn.addEventListener('click', () => {
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    });
+
     mostrarSeccion('dashboard');
     cargarDatos();
 });

--- a/index.html
+++ b/index.html
@@ -397,6 +397,8 @@
         </div>
     </div>
 
+    <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Volver arriba">⬆️</button>
+
     <script src="app.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -361,3 +361,26 @@ body.menu-abierto { overflow: hidden; }
 .factura-footer { margin-top: 40px; text-align: center; border-top: 1px solid #ccc; padding-top: 15px; }
 .factura-gracias-box p { margin: 0; font-style: italic; }
 .inventario-filtros{display:flex;gap:10px;align-items:center;margin:10px 0}
+
+/* Botón para volver arriba */
+.btn-scroll-top {
+    position: fixed;
+    bottom: 30px;
+    right: 30px;
+    display: none;
+    justify-content: center;
+    align-items: center;
+    width: 50px;
+    height: 50px;
+    border: none;
+    border-radius: 50%;
+    background-color: var(--color-primario);
+    color: var(--color-blanco);
+    cursor: pointer;
+    box-shadow: 0 4px 8px var(--color-sombra);
+    z-index: 1003;
+}
+
+.btn-scroll-top.mostrar {
+    display: flex;
+}


### PR DESCRIPTION
## Summary
- add floating "volver arriba" button to navigate long pages
- style and show/hide button based on scroll position
- enable smooth scrolling back to page top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e7ec10f083329d059885b4be206c