### PR TITLE
refactor: modularize frontend into ES modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -405,6 +405,6 @@
 
     <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Volver arriba">⬆️</button>
 
-    <script src="app.js"></script>
+    <script type="module" src="src/main.js"></script>
 </body>
 </html>

--- a/src/api.js
+++ b/src/api.js
@@ -1,0 +1,27 @@
+export const API_URL = window.location.hostname === 'localhost' ? 'http://localhost:3000' : window.location.origin;
+
+export async function getJSON(endpoint) {
+  const res = await fetch(`${API_URL}${endpoint}`);
+  if (!res.ok) throw new Error('Error en la petición');
+  return res.json();
+}
+
+export async function postJSON(endpoint, data) {
+  return fetch(`${API_URL}${endpoint}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+export async function patchJSON(endpoint, data) {
+  return fetch(`${API_URL}${endpoint}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+}
+
+export async function deleteJSON(endpoint) {
+  return fetch(`${API_URL}${endpoint}`, { method: 'DELETE' });
+}

--- a/src/clientes.js
+++ b/src/clientes.js
@@ -1,0 +1,13 @@
+import { getJSON, postJSON, patchJSON, deleteJSON } from './api.js';
+
+export function obtenerClientes() {
+  return getJSON('/clientes');
+}
+
+export function guardarCliente(id, datos) {
+  return id ? patchJSON(`/clientes/${id}`, datos) : postJSON('/clientes', datos);
+}
+
+export function eliminarCliente(id) {
+  return deleteJSON(`/clientes/${id}`);
+}

--- a/src/productos.js
+++ b/src/productos.js
@@ -1,0 +1,17 @@
+import { getJSON, postJSON, patchJSON, deleteJSON } from './api.js';
+
+export function obtenerProductos() {
+  return getJSON('/productos');
+}
+
+export function guardarProducto(id, datos) {
+  return id ? patchJSON(`/productos/${id}`, datos) : postJSON('/productos', datos);
+}
+
+export function eliminarProducto(id) {
+  return deleteJSON(`/productos/${id}`);
+}
+
+export function actualizarStock(id, nuevoStock) {
+  return patchJSON(`/productos/${id}`, { stock: nuevoStock });
+}

--- a/src/ventas.js
+++ b/src/ventas.js
@@ -1,0 +1,15 @@
+import { getJSON, postJSON, patchJSON, deleteJSON } from './api.js';
+
+export function obtenerVentas() {
+  return getJSON('/ventas');
+}
+
+export function registrarVenta(venta, nuevoNumeroFactura) {
+  const ventaReq = postJSON('/ventas', venta);
+  const metaReq = patchJSON('/metadata', { ultimaFactura: nuevoNumeroFactura });
+  return Promise.all([ventaReq, metaReq]);
+}
+
+export function eliminarVenta(id) {
+  return deleteJSON(`/ventas/${id}`);
+}


### PR DESCRIPTION
## Summary
- split network utilities into `src/api.js`
- move product, client and sales logic into dedicated modules
- convert app to use ES module entry point and update `index.html`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8efaed01c8332abcb985a2d118462