### PR TITLE
Agregar Service Worker para recursos estáticos

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,5 +406,14 @@
     <button id="btn-scroll-top" class="btn-scroll-top" aria-label="Volver arriba">⬆️</button>
 
     <script src="app.js"></script>
+    <script>
+        if ('serviceWorker' in navigator) {
+            window.addEventListener('load', () => {
+                navigator.serviceWorker.register('/service-worker.js').catch(err => {
+                    console.error('Error al registrar el Service Worker:', err);
+                });
+            });
+        }
+    </script>
 </body>
 </html>

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,48 @@
+const CACHE_NAME = 'static-cache-v1';
+const STATIC_ASSETS = [
+  '/',
+  '/index.html',
+  '/style.css',
+  '/app.js',
+  '/bandeja.png',
+  '/favicon.png',
+  '/logo.png'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(STATIC_ASSETS))
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(key => key !== CACHE_NAME).map(key => caches.delete(key)))
+    )
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', event => {
+  if (event.request.method !== 'GET') {
+    return;
+  }
+
+  event.respondWith(
+    caches.match(event.request).then(cachedResponse => {
+      const networkFetch = fetch(event.request).then(networkResponse => {
+        caches.open(CACHE_NAME).then(cache => cache.put(event.request, networkResponse.clone()));
+        return networkResponse;
+      }).catch(() => cachedResponse);
+
+      if (cachedResponse) {
+        event.waitUntil(networkFetch);
+        return cachedResponse;
+      }
+
+      return networkFetch;
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- Añadir `service-worker.js` con caché de recursos estáticos y estrategia cache-first con actualización en segundo plano.
- Registrar el Service Worker desde `index.html`.

## Testing
- `node --check service-worker.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_68a8efb42be4833299746e85c28bbfc8