### PR TITLE
Add Jest with utility unit tests and CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,16 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test

--- a/app.js
+++ b/app.js
@@ -670,6 +670,7 @@ function actualizarVistas() {
 }
 
 // ---- INICIALIZACIÓN ----
+if (typeof module === 'undefined') {
 document.addEventListener('DOMContentLoaded', () => {
     aplicarConfiguracionGuardada();
     configurarEventListenersDeColores();
@@ -726,6 +727,7 @@ document.addEventListener('DOMContentLoaded', () => {
     mostrarSeccion('dashboard');
     cargarDatos();
 });
+}
 
 function mostrarSeccion(idSeccion) {
     document.querySelectorAll('.seccion').forEach(s => s.classList.remove('activa'));
@@ -875,3 +877,7 @@ window.eliminarCategoria = eliminarCategoria;
     if (s) s.addEventListener('change', () => window.renderizarInventario());
   });
 })();
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { formatearCOP, safeParseInt };
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "appweb",
+  "version": "1.0.0",
+  "description": "",
+  "main": "app.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/app.test.js
+++ b/tests/app.test.js
@@ -1,0 +1,22 @@
+const { formatearCOP, safeParseInt } = require('../app');
+
+describe('formatearCOP', () => {
+  test('formatea números en pesos colombianos sin decimales', () => {
+    expect(formatearCOP(1234)).toBe('$\u00A01.234');
+  });
+  test('maneja cero correctamente', () => {
+    expect(formatearCOP(0)).toBe('$\u00A00');
+  });
+});
+
+describe('safeParseInt', () => {
+  test('convierte cadenas numéricas a enteros', () => {
+    expect(safeParseInt('42')).toBe(42);
+  });
+  test('retorna 0 para entradas no numéricas', () => {
+    expect(safeParseInt('abc')).toBe(0);
+  });
+  test('retorna 0 para undefined', () => {
+    expect(safeParseInt(undefined)).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- export and isolate utilities to support testing without triggering app initialization
- configure Jest and add unit tests for `formatearCOP` and `safeParseInt`
- add GitHub Actions workflow to run tests

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8efb555b4833281a037a3fe16c992